### PR TITLE
Prevent accidental replacement of vital template parts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ras-shoper-front",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "main": "src/index.ts",
   "author": "Przemysław Czachor <przemyslaw.czachor@fingoweb.com>",
   "license": "MIT",

--- a/src/managers/TemplateManager/TemplateManager.ts
+++ b/src/managers/TemplateManager/TemplateManager.ts
@@ -314,6 +314,10 @@ class TemplateManager {
 
       let modifiedTemplate = template;
       for (const key in mappedProduct) {
+        // mappedProduct contains more keys than the ones we should replace
+        // filter them to prevent accidentally replacing vital template parts
+        if (!key.match(/^\{\{.*}}$/i)) continue;
+
         const objKey = key as keyof typeof mappedProduct;
 
         const value = mappedProduct[objKey];


### PR DESCRIPTION
We noticed that in some cases, images in sponsored product were displayed incorrectly. URLs of those images looked malformed, examples being `/libraries/34.jpg/1px.gif` or `/skins/user/rwd_shoper_44/25262.jpg,25263.jpg/star0.png`.

After digging deeper, we identified that the problem was caused by faulty logic inside the part of the code responsible for replacing macros in the sponsored product template. Object containing strings to replace consisted of more properties than the ones matching the `{{.*}}` format. In the case of our malformed image URLs, one of the keys turned out to be `images`, effectively replacing the URL paths, which (before transformation) contained `.../images/...`.

To prevent current and future issues of this nature, we need to filter the keys to only allow replacement of ones that match the `{{.*}}` format.