### PR TITLE
Feature/add should remove decimal from price

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ yarn eslint - checks for eslint errors
 ```javascript
 window.OnetAdsConfig = {
     shouldShowLoader: true, // boolean
-    shouldRemoveDecimalFromPrice: false, // boolean
+    shouldRemoveDecimalFromProductPrice: false, // boolean - e.g. format price from '100,00 zł' to '100 zł'
     productsCount: 1, // number
     selectors: [
         {

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ yarn eslint - checks for eslint errors
 ```javascript
 window.OnetAdsConfig = {
     shouldShowLoader: true, // boolean
+    shouldRemoveDecimalFromPrice: false, // boolean
     productsCount: 1, // number
     selectors: [
         {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ras-shoper-front",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "main": "src/index.ts",
   "author": "Przemysław Czachor <przemyslaw.czachor@fingoweb.com>",
   "license": "MIT",

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import { NOT_VALID_TEMPLATE } from 'consts/templates';
 
 window.OnetAdsConfig = window.OnetAdsConfig || {
   shouldShowLoader: true,
-  shouldRemoveDecimalFromPrice: false,
+  shouldRemoveDecimalFromProductPrice: false,
   productsCount: 1,
   selectors: [],
   listingElementsToDelete: [],

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import { NOT_VALID_TEMPLATE } from 'consts/templates';
 
 window.OnetAdsConfig = window.OnetAdsConfig || {
   shouldShowLoader: true,
+  shouldRemoveDecimalFromPrice: false,
   productsCount: 1,
   selectors: [],
   listingElementsToDelete: [],

--- a/src/managers/TemplateManager/TemplateManager.ts
+++ b/src/managers/TemplateManager/TemplateManager.ts
@@ -20,6 +20,7 @@ import {
   BASKET_ID,
   CONTENT,
   PRODUCT_IMAGE_URL_KEY,
+  PRODUCT_PRICE_KEY,
   REPLACE_CONTENT_MAP,
 } from 'consts/replaceMap';
 import { BASIC_TAG } from 'consts/common';
@@ -43,6 +44,7 @@ import getMessage from 'utils/formatters/getMessage';
 import deleteProductFromDOM from 'utils/product/deleteProductFromDOM';
 import {
   attachAjaxCartEvent,
+  removeDecimalFromPrice,
   overrideProductStyles,
   reinitQuickView,
   updateIModulesAttributesIfExist,
@@ -313,6 +315,13 @@ class TemplateManager {
       if (template === NOT_VALID_TEMPLATE || template === null) return;
 
       let modifiedTemplate = template;
+
+      const shouldRemoveDecimalFromProductPrice= window.OnetAdsConfig.shouldRemoveDecimalFromProductPrice ?? false;
+
+      if (shouldRemoveDecimalFromProductPrice) {
+        mappedProduct[PRODUCT_PRICE_KEY] = removeDecimalFromPrice(mappedProduct[PRODUCT_PRICE_KEY]);
+      }
+
       for (const key in mappedProduct) {
         // mappedProduct contains more keys than the ones we should replace
         // filter them to prevent accidentally replacing vital template parts

--- a/src/managers/TemplateManager/TemplateManager.ts
+++ b/src/managers/TemplateManager/TemplateManager.ts
@@ -316,10 +316,13 @@ class TemplateManager {
 
       let modifiedTemplate = template;
 
-      const shouldRemoveDecimalFromProductPrice= window.OnetAdsConfig.shouldRemoveDecimalFromProductPrice ?? false;
+      const shouldRemoveDecimalFromProductPrice =
+        window.OnetAdsConfig.shouldRemoveDecimalFromProductPrice ?? false;
 
       if (shouldRemoveDecimalFromProductPrice) {
-        mappedProduct[PRODUCT_PRICE_KEY] = removeDecimalFromPrice(mappedProduct[PRODUCT_PRICE_KEY]);
+        mappedProduct[PRODUCT_PRICE_KEY] = removeDecimalFromPrice(
+          mappedProduct[PRODUCT_PRICE_KEY],
+        );
       }
 
       for (const key in mappedProduct) {

--- a/src/managers/TemplateManager/utils.ts
+++ b/src/managers/TemplateManager/utils.ts
@@ -152,10 +152,11 @@ const removeDecimalFromPrice = (price: string): string => {
 
   const parts = price.split(/[.,]/);
   const currencySign = parts[1] ? parts[1].replace(/\d{1,2}\s?/, '') : '';
-  const priceWithoutDecimal = parts[0].replace(/\u00A0/g, ' ') + ' ' + currencySign.trim();
+  const priceWithoutDecimal =
+    parts[0].replace(/\u00A0/g, ' ') + ' ' + currencySign.trim();
 
   return priceWithoutDecimal;
-}
+};
 
 export {
   initTemplateManager,
@@ -164,5 +165,5 @@ export {
   overrideProductStyles,
   updateIModulesAttributesIfExist,
   updateIModulesImagesIfExist,
-  removeDecimalFromPrice
+  removeDecimalFromPrice,
 };

--- a/src/managers/TemplateManager/utils.ts
+++ b/src/managers/TemplateManager/utils.ts
@@ -143,6 +143,20 @@ const updateIModulesImagesIfExist = (
   }
 };
 
+const removeDecimalFromPrice = (price: string): string => {
+  const regex = /^\d+\s?[a-zA-Z]+$/;
+
+  if (regex.test(price)) {
+    return price;
+  }
+
+  const parts = price.split(/[.,]/);
+  const currencySign = parts[1] ? parts[1].replace(/\d{1,2}\s?/, '') : '';
+  const priceWithoutDecimal = parts[0].replace(/\u00A0/g, ' ') + ' ' + currencySign.trim();
+
+  return priceWithoutDecimal;
+}
+
 export {
   initTemplateManager,
   attachAjaxCartEvent,
@@ -150,4 +164,5 @@ export {
   overrideProductStyles,
   updateIModulesAttributesIfExist,
   updateIModulesImagesIfExist,
+  removeDecimalFromPrice
 };

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -5,6 +5,7 @@ type TSelectorReplace = {
 
 type TOnetAdsConfig = {
   shouldShowLoader: boolean;
+  shouldRemoveDecimalFromProductPrice: boolean;
   productsCount: number;
   selectors?: TSelectorReplace[];
   listingElementsToDelete?: string[];


### PR DESCRIPTION
- Adding an option that, when enabled, formats the product price to a format without decimal numbers. 
- Problem noted on one shop that uses prices without decimal values on product listings. Shop: https://fotoforma.pl/
- In removeDecimalFromPrice, I check the price format, and remove numbers after a comma or full stop, and remove unnecessary spaces.